### PR TITLE
Resurrect support for Ruby 2.x

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -136,10 +136,18 @@ class Set
     @hash = orig.instance_variable_get(:@hash).dup
   end
 
-  # Clone internal hash.
-  def initialize_clone(orig, freeze: nil)
-    super
-    @hash = orig.instance_variable_get(:@hash).clone(freeze: freeze)
+  if Kernel.instance_method(:initialize_clone).arity != 1
+    # Clone internal hash.
+    def initialize_clone(orig, **options)
+      super
+      @hash = orig.instance_variable_get(:@hash).clone(**options)
+    end
+  else
+    # Clone internal hash.
+    def initialize_clone(orig)
+      super
+      @hash = orig.instance_variable_get(:@hash).clone
+    end
   end
 
   def freeze    # :nodoc:

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -739,7 +739,7 @@ class TC_Set < Test::Unit::TestCase
     set2.add 5
     assert_equal Set[1,2,3,5], set2
     assert_equal Set[1,2,3], set1
-  end
+  end if Kernel.instance_method(:initialize_clone).arity != 1
 
   def test_inspect
     set1 = Set[1, 2]


### PR DESCRIPTION
In Ruby 2.x, initialize_copy does not take a freeze option.