### PR TITLE
Add `Set#join`

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -628,6 +628,12 @@ class Set
     end
   end
 
+  # Returns a string created by converting each element of the set to a string
+  # See also: Array#join
+  def join(separator=nil)
+    to_a.join(separator)
+  end
+
   InspectKey = :__inspect_key__         # :nodoc:
 
   # Returns a string containing a human-readable representation of the

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -741,6 +741,11 @@ class TC_Set < Test::Unit::TestCase
     assert_equal Set[1,2,3], set1
   end if Kernel.instance_method(:initialize_clone).arity != 1
 
+  def test_join
+    assert_equal('123', Set[1, 2, 3].join)
+    assert_equal('1 & 2 & 3', Set[1, 2, 3].join(' & '))
+  end
+
   def test_inspect
     set1 = Set[1, 2]
     assert_equal('#<Set: {1, 2}>', set1.inspect)


### PR DESCRIPTION
[Fix #16991]

This PR simply defers the work to `Array`; I don't particularly care what happens to elements of sets that would be arrays or sets themselves (i.e. if `join` is recursive on them or not).