### PR TITLE
Add `Set#<=>`

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -45,9 +45,9 @@
 # == Comparison
 #
 # The comparison operators <, >, <=, and >= are implemented as
-# shorthand for the {proper_,}{subset?,superset?} methods.  However,
-# the <=> operator is intentionally left out because not every pair of
-# sets is comparable ({x, y} vs. {x, z} for example).
+# shorthand for the {proper_,}{subset?,superset?} methods.
+# The <=> operator reflects this order, or return `nil` for
+# sets that both have distinct elements ({x, y} vs. {x, z} for example).
 #
 # == Example
 #
@@ -301,6 +301,19 @@ class Set
     end
   end
   alias < proper_subset?
+
+  # Returns 0 if the set are equal,
+  # -1 / +1 if the set is a proper subset / superset of the given set,
+  # or nil if they both have unique elements.
+  def <=>(set)
+    return unless set.is_a?(Set)
+
+    case size <=> set.size
+    when -1 then -1 if proper_subset?(set)
+    when +1 then +1 if proper_superset?(set)
+    else 0 if self.==(set)
+    end
+  end
 
   # Returns true if the set and the given set have at least one
   # element in common.

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -332,6 +332,24 @@ class TC_Set < Test::Unit::TestCase
     }
   end
 
+  def test_spacecraft_operator
+    set = Set[1,2,3]
+
+    assert_nil(set <=> 2)
+
+    assert_nil(set <=> set.to_a)
+
+    [Set, Set2].each { |klass|
+      assert_equal(-1,  set <=> klass[1,2,3,4], klass.name)
+      assert_equal( 0,  set <=> klass[3,2,1]  , klass.name)
+      assert_equal(nil, set <=> klass[1,2,4]  , klass.name)
+      assert_equal(+1,  set <=> klass[2,3]    , klass.name)
+      assert_equal(+1,  set <=> klass[]       , klass.name)
+
+      assert_equal(0, Set[] <=> klass[], klass.name)
+    }
+  end
+
   def assert_intersect(expected, set, other)
     case expected
     when true


### PR DESCRIPTION
It compares only `Set`s. Other classes (in particular array) can not be compared and `nil` is returned.

The implementation of `<`, `>`, `subset?`, etc., could all depend on `<=>`, but it is more efficient to keep them as is. `a < b` can return `false` without having to know the reason (is it that `a > b` or do they both have distinct elements).