### PR TITLE
Raise informative error on `SortedSet` access

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -690,3 +690,5 @@ module Enumerable
     klass.new(self, *args, &block)
   end
 end
+
+autoload :SortedSet, "#{__dir__}/set/sorted_set"

--- a/lib/set/sorted_set.rb
+++ b/lib/set/sorted_set.rb
@@ -1,0 +1,6 @@
+begin
+  require 'sorted_set'
+rescue ::LoadError
+  raise "The `SortedSet` class has been extracted from the `set` library." \
+        "You must use the `sorted_set` gem or other alternatives."
+end

--- a/test/fixtures/fake_sorted_set_gem/sorted_set.rb
+++ b/test/fixtures/fake_sorted_set_gem/sorted_set.rb
@@ -1,0 +1,3 @@
+class SortedSet
+  # ...
+end

--- a/test/test_sorted_set.rb
+++ b/test/test_sorted_set.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: false
+require 'test/unit'
+require 'set'
+
+class TC_SortedSet < Test::Unit::TestCase
+  def base_dir
+    "#{__dir__}/../lib"
+  end
+
+  def assert_runs(ruby, options: nil)
+    options = ['-I', base_dir, *options]
+    r = system(RbConfig.ruby, *options, '-e', ruby)
+    assert(r)
+  end
+
+  def test_error
+    assert_runs <<~RUBY
+      require "set"
+
+      r = begin
+        puts SortedSet.new
+      rescue Exception => e
+        e.message
+      end
+      raise r unless r.match? /has been extracted/
+    RUBY
+  end
+
+  def test_ok_with_gem
+    assert_runs <<~RUBY, options: ['-I', "#{__dir__}/fixtures/fake_sorted_set_gem"]
+      require "set"
+
+      var = SortedSet.new.to_s
+    RUBY
+  end
+
+  def test_ok_require
+    assert_runs <<~RUBY, options: ['-I', "#{__dir__}/fixtures/fake_sorted_set_gem"]
+      require "set"
+      require "sorted_set"
+
+      var = SortedSet.new.to_s
+    RUBY
+  end
+end


### PR DESCRIPTION
The message says to use the gem `sorted_set` (name is available)