### PR TITLE
gemspec: This gem exposes 0 executables

### DIFF
--- a/set.gemspec
+++ b/set.gemspec
@@ -19,7 +19,5 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
This change removes unused configuration from the gemspec, to make it more focused, easier to read.