### PR TITLE
Get rid of use of `Gem::Version`

### DIFF
--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -841,7 +841,7 @@ end
 
 class TC_Set_Builtin < Test::Unit::TestCase
   private def should_omit?
-    Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.2.0') ||
+    (RUBY_VERSION.scan(/\d+/).map(&:to_i) <=> [3, 2]) < 0 ||
       !File.exist?(File.expand_path('../prelude.rb', __dir__))
   end
 


### PR DESCRIPTION
When retrying in ruby's test, it seems possible that `Gem` is not
loaded.

```
  1) Error:
TC_Set_Builtin#test_to_set:
NameError: uninitialized constant TC_Set_Builtin::Gem
    /export/home/chkbuild/chkbuild-gcc/tmp/build/20220708T070011Z/ruby/test/test_set.rb:844:in `should_omit?'
    /export/home/chkbuild/chkbuild-gcc/tmp/build/20220708T070011Z/ruby/test/test_set.rb:869:in `test_to_set'

  2) Error:
TC_Set_Builtin#test_Set:
NameError: uninitialized constant TC_Set_Builtin::Gem
    /export/home/chkbuild/chkbuild-gcc/tmp/build/20220708T070011Z/ruby/test/test_set.rb:844:in `should_omit?'
    /export/home/chkbuild/chkbuild-gcc/tmp/build/20220708T070011Z/ruby/test/test_set.rb:849:in
    `test_Set'
```

This is by `Gem::Version` only, just compare as array of integers
instead.