### PR TITLE
Remove `object_id` use in `Set#flatten`

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -361,16 +361,15 @@ class Set
     klass.new(self, *args, &block)
   end
 
-  def flatten_merge(set, seen = Set.new) # :nodoc:
+  def flatten_merge(set, seen = Set.new.compare_by_identity) # :nodoc:
     set.each { |e|
       if e.is_a?(Set)
-        if seen.include?(e_id = e.object_id)
+        unless seen.add?(e)
           raise ArgumentError, "tried to flatten recursive Set"
         end
 
-        seen.add(e_id)
         flatten_merge(e, seen)
-        seen.delete(e_id)
+        seen.delete(e)
       else
         add(e)
       end


### PR DESCRIPTION
Found this while auditing uses of `object_id` in `ruby/ruby`. Pulled out from ruby/ruby#9276.

This PR replaces look-ups into a `Set` by `object_id`s, with an identity Set (see [`Set#compare_by_identity`](https://ruby-doc.org/3.2.2/stdlibs/set/Set.html#method-i-compare_by_identity)). This has the same semantics but is faster and doesn't trigger allocation of IDs for these objects.