### PR TITLE
Use ruby/actions workflow for ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,18 @@ name: test
 on: [push, pull_request]
 
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby
+      min_version: 3.0
+
   build:
+    needs: ruby-versions
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.2, 3.1, "3.0", head ]
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Previously, Ruby versions in `test.yml` were specified using an array. However, this PR has been changed to use the [ruby/actions](https://github.com/ruby/actions/blob/master/.github/workflows/ruby_versions.yml) workflow for version.