### PR TITLE
Fix `^` to respect subclasses

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -659,7 +659,7 @@ class Set
   #     Set[1, 2] ^ Set[2, 3]                   #=> #<Set: {3, 1}>
   #     Set[1, 'b', 'c'] ^ ['b', 'd']           #=> #<Set: {"d", 1, "c"}>
   def ^(enum)
-    n = Set.new(enum)
+    n = self.class.new(enum)
     each { |o| n.add(o) unless n.delete?(o) }
     n
   end

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -643,6 +643,11 @@ class TC_Set < Test::Unit::TestCase
     ret = set ^ [2,4,5,5]
     assert_not_same(set, ret)
     assert_equal(Set[1,3,5], ret)
+
+    set2 = Set2[1,2,3,4]
+    ret2 = set2 ^ [2,4,5,5]
+    assert_instance_of(Set2, ret2)
+    assert_equal(Set2[1,3,5], ret2)
   end
 
   def test_eq


### PR DESCRIPTION
Suppose we define `MySet` as a subclass of `Set`.
The methods `MySet#&`, `MySet#|`, and `MySet#-` all return an instance of `MySet`, but only `MySet#^` returns an instance of `Set`.
Wouldn't it be better if `^` also returned an instance of `MySet`?

When `Set` was introduced in Ruby 1.8.0, the implementation up to 1.8.5 returned an instance of `MySet`.
This behavior changed at the following commit: a4104d6102a55d44247942892c7db0508edc15e7.

```
irb(main):001> class MySet < Set; end
=> nil
irb(main):002> ms = MySet[1, 2]
=> #<MySet: {1, 2}>
irb(main):003> s = Set[1, 3]
=> #<Set: {1, 3}>
irb(main):004> ms & s
=> #<MySet: {1}>
irb(main):005> ms | s
=> #<MySet: {1, 2, 3}>
irb(main):006> ms - s
=> #<MySet: {2}>
irb(main):007> ms ^ s
=> #<Set: {3, 2}>
```