### PR TITLE
Speed up `Set#flatten`

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -353,16 +353,19 @@ class Set
     klass.new(self, *args, &block)
   end
 
-  def flatten_merge(set, seen = Set.new) # :nodoc:
+  def flatten_merge(set, seen = {}) # :nodoc:
     set.each { |e|
       if e.is_a?(Set)
-        if seen.include?(e_id = e.object_id)
+        case seen[e_id = e.object_id]
+        when true
           raise ArgumentError, "tried to flatten recursive Set"
+        when false
+          next
         end
 
-        seen.add(e_id)
+        seen[e_id] = true
         flatten_merge(e, seen)
-        seen.delete(e_id)
+        seen[e_id] = false
       else
         add(e)
       end


### PR DESCRIPTION
Improved performance by ensuring that identical `Set` objects are processed only once.

# benchmark

```
prelude: |
  set = Set[1, 2]
  mul = Set[set, Set[set, 4], 3]
  large_set = Set.new(1..10000)
benchmark:
  - set.flatten
  - mul.flatten
  - large_set.flatten
```
compare-ruby: ruby 3.4.0dev (2024-11-29T02:48:10Z master 43dd9c721f) +PRISM [arm64-darwin22]
built-ruby: ruby 3.4.0dev (2024-11-29T02:48:10Z master 43dd9c721f) +PRISM [arm64-darwin22]

## Iteration per second (i/s)

|                   |compare-ruby|built-ruby|
|:------------------|-----------:|---------:|
|set.flatten        |      1.357M|    1.767M|
|                   |           -|     1.30x|
|mul.flatten        |    470.122k|  686.182k|
|                   |           -|     1.46x|
|large_set.flatten  |     899.207|   905.055|
|                   |           -|     1.01x|
