### PR TITLE
Exit early if using Ruby 3.5 with core Set

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -1,4 +1,12 @@
 # frozen_string_literal: true
+
+if RUBY_VERSION >= '3.5'
+  if defined?(Set) && defined?(Set.[]) && Set.method(:[]).source_location.nil?
+    # Remove defined? ... conditional after Ruby 3.5.0-preview2
+    return
+  end
+end
+
 # :markup: markdown
 #
 # set.rb - defines the Set class


### PR DESCRIPTION
Since core Set did not make Ruby 3.5.0-preview1, this currently does some checking to see if Set is already defined and implemented in core.  That can be removed after Ruby 3.5.0-preview2 is released.