### PR TITLE
Skip `SortedSet` tests with Ruby 3.5+

### DIFF
--- a/test/test_sorted_set.rb
+++ b/test/test_sorted_set.rb
@@ -42,4 +42,4 @@ class TC_SortedSet < Test::Unit::TestCase
       var = SortedSet.new.to_s
     RUBY
   end
-end
+end if defined?(SortedSet)


### PR DESCRIPTION
Ruby 3.5+ skip to auto-load SortedSet. We should skip that tests too.